### PR TITLE
Fix Component Crash When Input Schema Is Invalid

### DIFF
--- a/src/form.component.ts
+++ b/src/form.component.ts
@@ -76,7 +76,7 @@ export class FormComponent implements OnChanges {
       this.setActions();
     }
 
-    if (!this.schema.type) {
+    if (this.schema && !this.schema.type) {
       this.schema.type = 'object';
     }
 


### PR DESCRIPTION
+ Add logic to check existence of property `schema` before accessing `schema.type`